### PR TITLE
fix/ local varaibles too global

### DIFF
--- a/Hook/lua/ui/game/gamemain.lua
+++ b/Hook/lua/ui/game/gamemain.lua
@@ -1,8 +1,8 @@
 do
-	local CM = import('/lua/ui/game/commandmode.lua')
 
 	local oldOnSelectionChanged = OnSelectionChanged
 	function OnSelectionChanged(old, new, added, removed)
+        local CM = import('/lua/ui/game/commandmode.lua')
 		
 		for id, unit in added do
 			--	build a list of the player's structures for rebuilding. 


### PR DESCRIPTION
importing commandmode.lua for the entire gamemain.lua file causes a
crash when dragable buildques is enabled.