### PR TITLE
fix: reclaim labels dont show for rocks etc.

### DIFF
--- a/Hook/lua/UserSync.lua
+++ b/Hook/lua/UserSync.lua
@@ -47,6 +47,7 @@ do
 	
 	local oldOnSync = OnSync
 	function OnSync()
+		oldOnSync()
 		local CM = import('/lua/ui/game/commandmode.lua')
 		
 		for id, v in Sync.ReleaseIds do
@@ -75,6 +76,5 @@ do
 			end			
 		end
 		
-		oldOnSync()
 	end
 end


### PR DESCRIPTION
fix: reclaim labels dont show for props placed by map author (rocks, trees, other props with 10+ mass)